### PR TITLE
Remove dependencies to go-unixfs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/ipfs/go-ipns v0.0.2
 	github.com/ipfs/go-log v1.0.4
 	github.com/ipfs/go-path v0.0.9
-	github.com/ipfs/go-unixfs v0.2.4
 	github.com/ipfs/interface-go-ipfs-core v0.4.0
 	github.com/jbenet/go-is-domain v1.0.5
 	github.com/jbenet/goprocess v0.1.4

--- a/namesys_test.go
+++ b/namesys_test.go
@@ -11,7 +11,6 @@ import (
 	offroute "github.com/ipfs/go-ipfs-routing/offline"
 	ipns "github.com/ipfs/go-ipns"
 	path "github.com/ipfs/go-path"
-	unixfs "github.com/ipfs/go-unixfs"
 	opts "github.com/ipfs/interface-go-ipfs-core/options/namesys"
 	ci "github.com/libp2p/go-libp2p-core/crypto"
 	peer "github.com/libp2p/go-libp2p-core/peer"
@@ -110,7 +109,8 @@ func TestPublishWithCache0(t *testing.T) {
 	})
 
 	nsys := NewNameSystem(routing, dst, 0)
-	p, err := path.ParsePath(unixfs.EmptyDirNode().Cid().String())
+	// CID is arbitrary.
+	p, err := path.ParsePath("QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +142,8 @@ func TestPublishWithTTL(t *testing.T) {
 	})
 
 	nsys := NewNameSystem(routing, dst, 128)
-	p, err := path.ParsePath(unixfs.EmptyDirNode().Cid().String())
+	// CID is arbitrary.
+	p, err := path.ParsePath("QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The remaining dependency was in tests. We can hardcode a CID instead of requiring unixfs just to obtain an arbitrary CID that correspond to the empty directory.

This sits on top of #4.
