### PR TITLE
Use eth.domains instead of eth.link for .eth names

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -13,7 +13,7 @@ import (
 )
 
 const ethTLD = "eth"
-const linkTLD = "link"
+const linkTLD = "domains"
 
 // LookupTXTFunc is a generic type for a function that lookups TXT record values.
 type LookupTXTFunc func(name string) (txt []string, err error)

--- a/dns_test.go
+++ b/dns_test.go
@@ -126,7 +126,7 @@ func newMockDNS() *mockDNS {
 			"fqdn.example.com.": {
 				"dnslink=/ipfs/QmYvMB9yrsSf7RKBghkfwmHJkzJhW2ZgVwq3LxBXXPasFr",
 			},
-			"www.wealdtech.eth.link.": {
+			"www.wealdtech.eth.domains.": {
 				"dnslink=/ipns/ipfs.example.com",
 			},
 		},
@@ -168,5 +168,5 @@ func TestDNSResolution(t *testing.T) {
 	testResolution(t, r, "fqdn.example.com.", opts.DefaultDepthLimit, "/ipfs/QmYvMB9yrsSf7RKBghkfwmHJkzJhW2ZgVwq3LxBXXPasFr", nil)
 	testResolution(t, r, "www.wealdtech.eth", 1, "/ipns/ipfs.example.com", ErrResolveRecursion)
 	testResolution(t, r, "www.wealdtech.eth", 2, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
-	testResolution(t, r, "www.wealdtech.eth.link", 2, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
+	testResolution(t, r, "www.wealdtech.eth.domains", 2, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
 }


### PR DESCRIPTION
Since moving to a Cloudflare-hosted gateway for eth.link, we're looking to reduce the impact our (ENS's) infrastructure has on the reliability of the service. We currently operate custom proxying nameservers on eth.link that forward to CloudFlare's DoH nameservers.

Thanks to some improvements at cloudflare, we can migrate eth.link to using their nameservers directly, except that their servers won't serve the TXT records required by IPFS's .eth integration. In order to allow this improvement to the eth.link service without affecting IPFS users who rely on the TXT records, we'd like to move IPFS to resolving records via eth.domains instead of eth.link. We'll maintain this service exclusively for IPFS and other systems needing to look up ENS content hashes as text records, while direct traffic will continue to go to eth.link via the new, more efficient path using only CloudFlare infrastructure.

If you're happy to merge this and push it into the next release, @lidel, I'd be most grateful.