### PR TITLE
Output a more useful resolve error

### DIFF
--- a/base.go
+++ b/base.go
@@ -2,6 +2,7 @@ package namesys
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -36,6 +37,14 @@ func resolve(ctx context.Context, r resolver, name string, options opts.ResolveO
 		}
 	}
 
+	if err == ErrResolveFailed {
+		i := len(name) - 1
+		for i >= 0 && name[i] != '/' {
+			i--
+		}
+		// Wrap error so that it can be tested if it is a ErrResolveFailed
+		err = fmt.Errorf("%w: %s is missing DNSLink record (https://docs.ipfs.io/concepts/dnslink/)", ErrResolveFailed, name[i+1:])
+	}
 	return p, err
 }
 

--- a/base.go
+++ b/base.go
@@ -43,7 +43,7 @@ func resolve(ctx context.Context, r resolver, name string, options opts.ResolveO
 			i--
 		}
 		// Wrap error so that it can be tested if it is a ErrResolveFailed
-		err = fmt.Errorf("%w: %s is missing DNSLink record (https://docs.ipfs.io/concepts/dnslink/)", ErrResolveFailed, name[i+1:])
+		err = fmt.Errorf("%w: %q is missing a DNSLink record (https://docs.ipfs.io/concepts/dnslink/)", ErrResolveFailed, name[i+1:])
 	}
 	return p, err
 }

--- a/namesys_test.go
+++ b/namesys_test.go
@@ -2,6 +2,7 @@ package namesys
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -25,7 +26,7 @@ type mockResolver struct {
 func testResolution(t *testing.T, resolver Resolver, name string, depth uint, expected string, expError error) {
 	t.Helper()
 	p, err := resolver.Resolve(context.Background(), name, opts.Depth(depth))
-	if err != expError {
+	if !errors.Is(err, expError) {
 		t.Fatal(fmt.Errorf(
 			"expected %s with a depth of %d to have a '%s' error, but got '%s'",
 			name, depth, expError, err))


### PR DESCRIPTION
This outputs a missage that blames a specific sife for not having DNSLink record.  For example, the error message looks like:
```sh
could not resolve name: bad.example.net is missing DNSLink record (https://docs.ipfs.io/concepts/dnslink/)
```

The "could not resolve name" portion is still present because the returned error wraps the original `ErrResolveFailed`, allowing code to test if the error is an `ErrResolveFailed` error.

This addresses [go-ipfs issue 8000](https://github.com/ipfs/go-ipfs/issues/8000)