### PR TITLE
Properly report DNSLink errors

### DIFF
--- a/base.go
+++ b/base.go
@@ -2,7 +2,6 @@ package namesys
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -37,14 +36,6 @@ func resolve(ctx context.Context, r resolver, name string, options opts.ResolveO
 		}
 	}
 
-	if err == ErrResolveFailed {
-		i := len(name) - 1
-		for i >= 0 && name[i] != '/' {
-			i--
-		}
-		// Wrap error so that it can be tested if it is a ErrResolveFailed
-		err = fmt.Errorf("%w: %q is missing a DNSLink record (https://docs.ipfs.io/concepts/dnslink/)", ErrResolveFailed, name[i+1:])
-	}
 	return p, err
 }
 


### PR DESCRIPTION
Only report that there is no DNSLink for a name when there are no DNSLink TXT records available for that name.  For all other errors, such as being offline, report the more general "cannot resolve name" error.

This fixes issue #11