### PR TITLE
chore: fixup tests and ensure go vet and staticcheck pass

### DIFF
--- a/dns_test.go
+++ b/dns_test.go
@@ -21,7 +21,6 @@ func (m *mockDNS) lookupTXT(ctx context.Context, name string) (txt []string, err
 }
 
 func TestDnsEntryParsing(t *testing.T) {
-
 	goodEntries := []string{
 		"QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD",
 		"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD",

--- a/namesys_test.go
+++ b/namesys_test.go
@@ -160,7 +160,7 @@ func TestPublishWithTTL(t *testing.T) {
 	ttl := 1 * time.Second
 	eol := time.Now().Add(2 * time.Second)
 
-	ctx := context.WithValue(context.Background(), "ipns-publish-ttl", ttl)
+	ctx := ContextWithTTL(context.Background(), ttl)
 	err = nsys.Publish(ctx, priv, p)
 	if err != nil {
 		t.Fatal(err)

--- a/publisher.go
+++ b/publisher.go
@@ -206,7 +206,7 @@ func (p *IpnsPublisher) PublishWithEOL(ctx context.Context, k ci.PrivKey, value 
 // as such, i'm using the context to wire it through to avoid changing too
 // much code along the way.
 func checkCtxTTL(ctx context.Context) (time.Duration, bool) {
-	v := ctx.Value("ipns-publish-ttl")
+	v := ctx.Value(ttlContextKey)
 	if v == nil {
 		return 0, false
 	}
@@ -295,4 +295,14 @@ func PublishEntry(ctx context.Context, r routing.ValueStore, ipnskey string, rec
 // PkKeyForID returns the public key routing key for the given peer ID.
 func PkKeyForID(id peer.ID) string {
 	return "/pk/" + string(id)
+}
+
+// contextKey is a private comparable type used to hold value keys in contexts
+type contextKey string
+
+var ttlContextKey contextKey = "ipns-publish-ttl"
+
+// ContextWithTTL returns a copy of the parent context with an added value representing the TTL
+func ContextWithTTL(ctx context.Context, ttl time.Duration) context.Context {
+	return context.WithValue(context.Background(), ttlContextKey, ttl)
 }

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -3,9 +3,10 @@ package namesys
 import (
 	"context"
 	"crypto/rand"
-	"github.com/ipfs/go-path"
 	"testing"
 	"time"
+
+	"github.com/ipfs/go-path"
 
 	ds "github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"


### PR DESCRIPTION
This adds a new function `ContextWithTTL` which returns a context with an embedded TTL. This is part of a fix for a staticcheck which was flagging the use of a bare string as a context key. The preferred way of using custom context keys is to create an unexported type to prevent the possibility of collisions. Since the key is unexported `ContextWithTTL` is needed to allow external clients to set the TTL. Usually a second exported function is provided to extract the TTL from a context and this could be done by renaming `checkCtxTTL` to something more externally friendly such as `TTLFromContext`