### PR TITLE
feat: add *Many vectorised publishing operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.0.15
 	github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc
+	go.uber.org/multierr v1.7.0
 )
 
 go 1.16

--- a/publisher.go
+++ b/publisher.go
@@ -16,6 +16,7 @@ import (
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	routing "github.com/libp2p/go-libp2p-core/routing"
 	base32 "github.com/whyrusleeping/base32"
+	"go.uber.org/multierr"
 )
 
 const ipnsPrefix = "/ipns/"
@@ -46,8 +47,15 @@ func NewIpnsPublisher(route routing.ValueStore, ds ds.Datastore) *IpnsPublisher 
 // Publish implements Publisher. Accepts a keypair and a value,
 // and publishes it out to the routing system
 func (p *IpnsPublisher) Publish(ctx context.Context, k crypto.PrivKey, value path.Path) error {
-	log.Debugf("Publish %s", value)
-	return p.PublishWithEOL(ctx, k, value, time.Now().Add(DefaultRecordEOL))
+	return p.PublishMany(ctx, []PublishItem{{Key: k, Value: value}})
+}
+
+// PublishMany is similar to Publish except it accepts many different paths
+func (p *IpnsPublisher) PublishMany(ctx context.Context, entries []PublishItem) error {
+	for _, v := range entries {
+		log.Debugf("Publish %s", v.Value)
+	}
+	return p.PublishWithEOLMany(ctx, entries, time.Now().Add(DefaultRecordEOL))
 }
 
 // IpnsDsKey returns a datastore key given an IPNS identifier (peer
@@ -191,12 +199,35 @@ func (p *IpnsPublisher) updateRecord(ctx context.Context, k crypto.PrivKey, valu
 // PublishWithEOL is a temporary stand in for the ipns records implementation
 // see here for more details: https://github.com/ipfs/specs/tree/master/records
 func (p *IpnsPublisher) PublishWithEOL(ctx context.Context, k crypto.PrivKey, value path.Path, eol time.Time) error {
-	record, err := p.updateRecord(ctx, k, value, eol)
-	if err != nil {
-		return err
+	// Use *Many route to avoid maintaining two code bases.
+	return p.PublishWithEOLMany(ctx, []PublishItem{{Key: k, Value: value}}, eol)
+}
+
+type PublishItem struct {
+	Key   crypto.PrivKey
+	Value path.Path
+}
+
+// PublishWithEOLMany is similar to PublishWithEOL but it accepts many key + path pairs
+func (p *IpnsPublisher) PublishWithEOLMany(ctx context.Context, entries []PublishItem, eol time.Time) error {
+	l := len(entries)
+	outEntries := make([]PutRecordToRoutingManyEntry, l)
+	good := 0
+	// Since error is cold path we don't need to waste time allocating if it's empty.
+	var errors []error
+	var err error
+	for _, v := range entries {
+		k := v.Key
+		outEntries[good].Record, err = p.updateRecord(ctx, k, v.Value, eol)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+		outEntries[good].Key = k.GetPublic()
+		good++
 	}
 
-	return PutRecordToRouting(ctx, p.routing, k.GetPublic(), record)
+	return multierr.Combine(append(errors, PutRecordToRoutingMany(ctx, p.routing, outEntries))...)
 }
 
 // setting the TTL on published records is an experimental feature.
@@ -216,77 +247,193 @@ func checkCtxTTL(ctx context.Context) (time.Duration, bool) {
 // keyed on the ID associated with the provided public key. The public key is
 // also made available to the routing system so that entries can be verified.
 func PutRecordToRouting(ctx context.Context, r routing.ValueStore, k crypto.PubKey, entry *pb.IpnsEntry) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	return PutRecordToRoutingMany(ctx, r, []PutRecordToRoutingManyEntry{{Key: k, Record: entry}})
+}
 
-	errs := make(chan error, 2) // At most two errors (IPNS, and public key)
+type PutRecordToRoutingManyEntry struct {
+	Key    crypto.PubKey
+	Record *pb.IpnsEntry
+}
 
-	if err := ipns.EmbedPublicKey(k, entry); err != nil {
-		return err
-	}
+// PutRecordToRoutingMany is similar to PutRecordToRouting but it accepts many key + entry pairs
+func PutRecordToRoutingMany(ctx context.Context, r routing.ValueStore, entries []PutRecordToRoutingManyEntry) error {
+	var errors []error
+	l := len(entries)
+	ipnsGood := 0
+	ipnsPublishEntries := make([]PublishEntryManyItem, l)
+	pubkeyGood := 0
+	pubkeyPublishEntries := make([]PublishPublicKeyManyEntry, l)
+	for _, v := range entries {
+		k := v.Key
+		record := v.Record
+		err := ipns.EmbedPublicKey(k, record)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
 
-	id, err := peer.IDFromPublicKey(k)
-	if err != nil {
-		return err
-	}
+		id, err := peer.IDFromPublicKey(k)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
 
-	go func() {
-		errs <- PublishEntry(ctx, r, ipns.RecordKey(id), entry)
-	}()
+		ipnsPublishEntries[ipnsGood] = PublishEntryManyItem{Ipnskey: ipns.RecordKey(id), Record: record}
+		ipnsGood++
 
-	// Publish the public key if a public key cannot be extracted from the ID
-	// TODO: once v0.4.16 is widespread enough, we can stop doing this
-	// and at that point we can even deprecate the /pk/ namespace in the dht
-	//
-	// NOTE: This check actually checks if the public key has been embedded
-	// in the IPNS entry. This check is sufficient because we embed the
-	// public key in the IPNS entry if it can't be extracted from the ID.
-	if entry.PubKey != nil {
-		go func() {
-			errs <- PublishPublicKey(ctx, r, PkKeyForID(id), k)
-		}()
-
-		if err := waitOnErrChan(ctx, errs); err != nil {
-			return err
+		// Publish the public key if a public key cannot be extracted from the ID
+		// TODO: once v0.4.16 is widespread enough, we can stop doing this
+		// and at that point we can even deprecate the /pk/ namespace in the dht
+		//
+		// NOTE: This check actually checks if the public key has been embedded
+		// in the IPNS entry. This check is sufficient because we embed the
+		// public key in the IPNS entry if it can't be extracted from the ID.
+		if record.PubKey != nil {
+			pubkeyPublishEntries[pubkeyGood] = PublishPublicKeyManyEntry{Key: PkKeyForID(id), Pubkey: k}
+			pubkeyGood++
 		}
 	}
 
-	return waitOnErrChan(ctx, errs)
-}
+	keysEntry, dataEntry, errEntry := preparePublishEntryMany(ipnsPublishEntries[:ipnsGood])
+	keysPubkey, dataPubkey, errPubkey := preparePublishPublicKeyMany(pubkeyPublishEntries[:pubkeyGood])
 
-func waitOnErrChan(ctx context.Context, errs chan error) error {
-	select {
-	case err := <-errs:
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	return multierr.Combine(
+		append(errors, errEntry, errPubkey,
+			execPut(ctx, r, append(keysEntry, keysPubkey...), append(dataEntry, dataPubkey...)),
+		)...,
+	)
 }
 
 // PublishPublicKey stores the given public key in the ValueStore with the
 // given key.
 func PublishPublicKey(ctx context.Context, r routing.ValueStore, k string, pubk crypto.PubKey) error {
-	log.Debugf("Storing pubkey at: %s", k)
-	pkbytes, err := crypto.MarshalPublicKey(pubk)
-	if err != nil {
-		return err
-	}
+	return PublishPublicKeyMany(ctx, r, []PublishPublicKeyManyEntry{{Key: k, Pubkey: pubk}})
+}
 
-	// Store associated public key
-	return r.PutValue(ctx, k, pkbytes)
+type PublishPublicKeyManyEntry struct {
+	Key    string
+	Pubkey crypto.PubKey
+}
+
+// PublishPublicKeyMany is similar to PublishPublicKey but it accepts many key + pubkey pairs
+func PublishPublicKeyMany(ctx context.Context, r routing.ValueStore, entries []PublishPublicKeyManyEntry) error {
+	keys, data, err := preparePublishPublicKeyMany(entries)
+	return multierr.Append(err, execPut(ctx, r, keys, data))
+}
+
+// preparePublishPublicKeyMany prepare arguments for execPut, this is usefull
+// because that allows to bundle many different prepared payloads into a single PutMany
+func preparePublishPublicKeyMany(entries []PublishPublicKeyManyEntry) ([]string, [][]byte, error) {
+	var err error
+	var errors []error
+	l := len(entries)
+	good := 0
+	data := make([][]byte, l)
+	keys := make([]string, l)
+	for _, v := range entries {
+		data[good], err = crypto.MarshalPublicKey(v.Pubkey)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+		key := v.Key
+		log.Debugf("Storing pubkey at: %s", key)
+		keys[good] = key
+		good++
+	}
+	data = data[:good]
+	keys = keys[:good]
+
+	return keys, data, multierr.Combine(errors...)
 }
 
 // PublishEntry stores the given IpnsEntry in the ValueStore with the given
 // ipnskey.
 func PublishEntry(ctx context.Context, r routing.ValueStore, ipnskey string, rec *pb.IpnsEntry) error {
-	data, err := proto.Marshal(rec)
-	if err != nil {
-		return err
+	return PublishEntryMany(ctx, r, []PublishEntryManyItem{{Ipnskey: ipnskey, Record: rec}})
+}
+
+type putManyRouter interface {
+	PutMany(ctx context.Context, keys []string, values [][]byte) error
+}
+
+type PublishEntryManyItem struct {
+	Ipnskey string
+	Record  *pb.IpnsEntry
+}
+
+// PublishEntryMany is similar to PublishEntry but accepts many key + entry pairs
+func PublishEntryMany(ctx context.Context, r routing.ValueStore, entries []PublishEntryManyItem) error {
+	keys, data, err := preparePublishEntryMany(entries)
+	return multierr.Append(err, execPut(ctx, r, keys, data))
+}
+
+// preparePublishEntryMany prepare arguments for execPut, this is usefull
+// because that allows to bundle many different prepared payloads into a single PutMany
+func preparePublishEntryMany(entries []PublishEntryManyItem) ([]string, [][]byte, error) {
+	var err error
+	var errors []error
+	l := len(entries)
+	good := 0
+	data := make([][]byte, l)
+	keys := make([]string, l)
+	for _, v := range entries {
+		data[good], err = proto.Marshal(v.Record)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+		key := v.Ipnskey
+		log.Debugf("Storing ipns entry at: %s", key)
+		keys[good] = key
+		good++
+	}
+	data = data[:good]
+	keys = keys[:good]
+
+	return keys, data, multierr.Combine(errors...)
+}
+
+func execPut(ctx context.Context, r routing.ValueStore, keys []string, data [][]byte) error {
+	if len(keys) != len(data) {
+		panic("unmatched sisterlists")
 	}
 
-	log.Debugf("Storing ipns entry at: %s", ipnskey)
-	// Store ipns entry at "/ipns/"+h(pubkey)
-	return r.PutValue(ctx, ipnskey, data)
+	rMany, ok := r.(putManyRouter)
+	if ok {
+		return rMany.PutMany(ctx, keys, data)
+
+	} else {
+		goodCount := len(keys)
+		switch goodCount {
+		case 0:
+			return nil
+
+		case 1:
+			return r.PutValue(ctx, keys[0], data[0])
+
+		default:
+			// Fallback to a parallel Put if the router doesn't support many
+			var errors []error
+			var wg sync.WaitGroup
+			var errLock sync.Mutex
+			wg.Add(goodCount)
+			for goodCount != 0 {
+				goodCount--
+				go func(i int) {
+					defer wg.Done()
+					err := r.PutValue(ctx, keys[i], data[i])
+					if err != nil {
+						errLock.Lock()
+						errors = append(errors, err)
+						errLock.Unlock()
+					}
+				}(goodCount)
+			}
+			wg.Wait()
+			return multierr.Combine(errors...)
+		}
+	}
 }
 
 // PkKeyForID returns the public key routing key for the given peer ID.


### PR DESCRIPTION
Closes: ipfs/boxo#348 

Thoses operations do the same thing than the scalar operations they replace but accepts many elements, this allows to use the PutMany interface on routings that supports it and yield a subsentantial speed boost.

All the scalar function that have been replaced has been replaced by stubs that just move to the vectorized codepath ASAP.
This is done to increase maintainability of the code and is, to me, an acceptable tradeoff given that this is cold code runned once each 12 hours.

That increase maintainability because if the scalar functions kept a scalar codepath, it would be faster for single publishes, but that requires us to maintain two codebase, any change to the scalar codebase would need to be done to the vectorised one too without the compiler warning you of the requirement and vice versa.

# Draft:
Feature lacking:
- [x] Rebase to master
- [ ] Vectorized tests (note the scalar tests already there do use the vectorized codepath but with borring single item lists)