### PR TITLE
fix: CIDv1 error with go-libp2p 0.19

### DIFF
--- a/namesys.go
+++ b/namesys.go
@@ -202,12 +202,12 @@ func (ns *mpns) resolveOnceAsync(ctx context.Context, name string, options opts.
 
 	// CIDs in IPNS are expected to have libp2p-key multicodec
 	// We ease the transition by returning a more meaningful error with a valid CID
-	if err != nil && err.Error() == "can't convert CID of type protobuf to a peer ID" {
+	if err != nil {
 		ipnsCid, cidErr := cid.Decode(key)
 		if cidErr == nil && ipnsCid.Version() == 1 && ipnsCid.Type() != cid.Libp2pKey {
 			fixedCid := cid.NewCidV1(cid.Libp2pKey, ipnsCid.Hash()).String()
 			codecErr := fmt.Errorf("peer ID represented as CIDv1 require libp2p-key multicodec: retry with /ipns/%s", fixedCid)
-			log.Debugf("RoutingResolver: could not convert public key hash %s to peer ID: %s\n", key, codecErr)
+			log.Debugf("RoutingResolver: could not convert public key hash %q to peer ID: %s\n", key, codecErr)
 			out <- onceResult{err: codecErr}
 			close(out)
 			return out


### PR DESCRIPTION
This PR fixes regression detected by failure in  `t0160-resolve.sh` sharness test in https://github.com/ipfs/go-ipfs/pull/8868 (where we test go-libp2p 0.19)

- The error message changed in  recent `go-libp2p-core/peer` (go-libp2p 0.19) 
  - Due to string matching, namesys no longer returned a user-friendly error message 
  - String matching is a bad practice so just removing it, as we validate CID and codec already.
